### PR TITLE
enable database configuration per database provider (Text and Number Only)

### DIFF
--- a/.nox/design/sample.solution.nox.yaml
+++ b/.nox/design/sample.solution.nox.yaml
@@ -413,7 +413,7 @@ infrastructure:
 
       # Sql Server
       serverUri: sqlserver.iwgplc.com
-      provider: sqlServer
+      provider: sqLite
       port: 1433
       user: sqluser
       password: sqlpassword

--- a/src/Nox.Abstractions/Infrastructure/Persistence/INoxDatabaseProvider.cs
+++ b/src/Nox.Abstractions/Infrastructure/Persistence/INoxDatabaseProvider.cs
@@ -4,6 +4,6 @@ namespace Nox.Abstractions.Infrastructure.Persistence
 {
     public interface INoxDatabaseProvider
     {
-        string ToDatabaseColumnType<T, TO>(TO options) where T : INoxType where TO : class; //TODO TO INoxOptions?
+       
     }
 }

--- a/src/Nox.Abstractions/Nox.Abstractions.csproj
+++ b/src/Nox.Abstractions/Nox.Abstractions.csproj
@@ -8,7 +8,7 @@
     <ItemGroup>
         <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="7.0.0" />
         <PackageReference Include="Microsoft.Extensions.Logging" Version="7.0.0" />
-        <PackageReference Include="Nox.Types" Version="1.0.8" />
+        <PackageReference Include="Nox.Types" Version="1.0.10" />
         <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="7.0.0" />
     </ItemGroup>
         

--- a/src/Nox.Generator.sln
+++ b/src/Nox.Generator.sln
@@ -9,13 +9,13 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "NoxSourceGeneratorTests", "
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "SampleWebApp", "SampleWebApp\SampleWebApp.csproj", "{8FC400B5-B768-4712-BDBA-359BC2606B1B}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Nox.Lib", "Nox.Lib\Nox.Lib.csproj", "{15AAEF8D-469F-4EA3-80D3-8D746A53E18A}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Nox.Lib", "Nox.Lib\Nox.Lib.csproj", "{15AAEF8D-469F-4EA3-80D3-8D746A53E18A}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Nox.Monitoring.ElasticApm", "Nox.Monitoring.ElasticApm\Nox.Monitoring.ElasticApm.csproj", "{23D83C90-BC4D-4D55-982E-67A55EE97D0D}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Nox.Monitoring.ElasticApm", "Nox.Monitoring.ElasticApm\Nox.Monitoring.ElasticApm.csproj", "{23D83C90-BC4D-4D55-982E-67A55EE97D0D}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Nox.Abstractions", "Nox.Abstractions\Nox.Abstractions.csproj", "{477711F6-C7D5-45D5-8E8B-A1810DD307D1}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Nox.Abstractions", "Nox.Abstractions\Nox.Abstractions.csproj", "{477711F6-C7D5-45D5-8E8B-A1810DD307D1}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Nox.Monitoring", "Nox.Monitoring\Nox.Monitoring.csproj", "{E054D012-2AA7-4B70-9CDC-253FF510B0C8}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Nox.Monitoring", "Nox.Monitoring\Nox.Monitoring.csproj", "{E054D012-2AA7-4B70-9CDC-253FF510B0C8}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution

--- a/src/Nox.Generator.sln.DotSettings
+++ b/src/Nox.Generator.sln.DotSettings
@@ -1,0 +1,2 @@
+﻿<wpf:ResourceDictionary xml:space="preserve" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:s="clr-namespace:System;assembly=mscorlib" xmlns:ss="urn:shemas-jetbrains-com:settings-storage-xaml" xmlns:wpf="http://schemas.microsoft.com/winfx/2006/xaml/presentation">
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=Sqlite/@EntryIndexedValue">True</s:Boolean></wpf:ResourceDictionary>

--- a/src/Nox.Generator/Common/CodeBuilder.cs
+++ b/src/Nox.Generator/Common/CodeBuilder.cs
@@ -12,6 +12,9 @@ internal class CodeBuilder
 
     private readonly StringBuilder _stringBuilder;
 
+    private static readonly string _trueString = true.ToString().ToLower();
+    private static readonly string _falseString = false.ToString().ToLower();
+
     private int _indentation = 0;
 
     private readonly SourceProductionContext _context;
@@ -45,6 +48,11 @@ internal class CodeBuilder
     public void Append(string text = "")
     {
         _stringBuilder.Append(text);
+    }
+
+    public void Append(bool value)
+    {
+        _stringBuilder.Append(From(value));
     }
 
     public void StartBlock()
@@ -86,5 +94,10 @@ internal class CodeBuilder
     public void GenerateSourceCode()
     {
         _context.AddSource(_sourceFileName, SourceText.From(_stringBuilder.ToString(), Encoding.UTF8));
+    }
+
+    public string From(bool value)
+    {
+        return value ? _trueString : _falseString;
     }
 }

--- a/src/Nox.Generator/Infrastructure/Persistence/DatabaseConfiguration/ConfigurationDefaults.cs
+++ b/src/Nox.Generator/Infrastructure/Persistence/DatabaseConfiguration/ConfigurationDefaults.cs
@@ -1,0 +1,73 @@
+﻿using System;
+using Nox.Types;
+
+namespace Nox.Generator.Infrastructure.Persistence.DatabaseConfiguration;
+
+internal static class ConfigurationDefaults
+{
+    public static DatabaseAttributeConfig GetDefaultOptions(TextTypeOptions options)
+    {
+        return new DatabaseAttributeConfig()
+        {
+            IsSingleProperty = true,
+            HasConversionTypeFullName = "Nox.Types.EntityFramework.Types.TextConverter",
+            IsUnicode = options.IsUnicode,
+            HasMaxLength = options.MaxLength
+        };
+    }
+    public static IDatabaseAttributeConfig GetDefaultOptions(NumberTypeOptions options)
+    {
+        var converterName = ComputeNumberConverterName(options);
+        return new DatabaseAttributeConfig()
+        {
+            IsSingleProperty = true,
+            
+            HasConversionTypeFullName = $"Nox.Types.EntityFramework.Types.{converterName}",
+            // .HasPrecision(9, 4); // or whatever your schema specifies
+        };
+    }
+
+    private static string ComputeNumberConverterName(NumberTypeOptions options)
+    {
+        if (options.DecimalDigits == 0) // integer
+        {
+            //see https://learn.microsoft.com/en-us/dotnet/csharp/language-reference/builtin-types/integral-numeric-types
+            if (options is { MaxValue: <= byte.MaxValue, MinValue: >= byte.MinValue })
+            {
+                return "NumberToByteConverter";
+            }
+            if (options is { MaxValue: <= short.MaxValue, MinValue: >= short.MinValue })
+            {
+                return "NumberToShortConverter";
+            }
+            if (options is { MaxValue: <= Int32.MaxValue, MinValue: >= Int32.MinValue })
+            {
+                return "NumberToInt32Converter";
+            }
+            if (options is { MaxValue: <= Int64.MaxValue, MinValue: >= Int64.MinValue })
+            {
+                return "NumberToInt64Converter";
+            }
+        }
+        //See https://learn.microsoft.com/en-us/dotnet/csharp/language-reference/builtin-types/floating-point-numeric-types
+        //Opt by Decimal, if precision is higher then 17
+        if (options is { DecimalDigits: > 17 })
+        {
+            return "NumberToDecimalConverter";
+        }
+        
+        //Fall back to double, more range less precision
+        return "NumberToDoubleConverter";
+    }
+
+    // TODO 
+    public static bool IsCompoundType(Enum value)
+    {
+        var fi = value.GetType().GetField(value.ToString());
+        var attributes = (CompoundTypeAttribute[])
+            fi.GetCustomAttributes(typeof(CompoundTypeAttribute), false);
+        return (attributes != null && attributes.Length > 0);
+    }
+
+    
+}

--- a/src/Nox.Generator/Infrastructure/Persistence/DatabaseConfiguration/DatabaseAttributeConfig.cs
+++ b/src/Nox.Generator/Infrastructure/Persistence/DatabaseConfiguration/DatabaseAttributeConfig.cs
@@ -1,0 +1,10 @@
+﻿namespace Nox.Generator.Infrastructure.Persistence.DatabaseConfiguration;
+
+internal sealed class DatabaseAttributeConfig : IDatabaseAttributeConfig
+{
+    public bool IsSingleProperty { get; set; }
+    public string? HasColumnType { get; set; }
+    public string? HasConversionTypeFullName { get; set; }
+    public uint? HasMaxLength { get; set; }
+    public bool IsUnicode { get; set; } = false;
+}

--- a/src/Nox.Generator/Infrastructure/Persistence/DatabaseConfiguration/DatabaseAttributeConfigurationInstances.cs
+++ b/src/Nox.Generator/Infrastructure/Persistence/DatabaseConfiguration/DatabaseAttributeConfigurationInstances.cs
@@ -1,0 +1,13 @@
+﻿using System.Collections.Generic;
+
+namespace Nox.Generator.Infrastructure.Persistence.DatabaseConfiguration;
+
+internal static class DatabaseAttributeConfigurationInstances
+{
+    public static readonly Dictionary<string, IDatabaseAttributeConfiguration> Map =
+        new()
+        {
+            { "sqLite", new SqLiteDatabaseAttributeConfiguration() },
+            { "mySql", new MySqlDatabaseAttributeConfiguration() }
+        };
+}

--- a/src/Nox.Generator/Infrastructure/Persistence/DatabaseConfiguration/IDatabaseAttributeConfig.cs
+++ b/src/Nox.Generator/Infrastructure/Persistence/DatabaseConfiguration/IDatabaseAttributeConfig.cs
@@ -1,0 +1,10 @@
+﻿namespace Nox.Generator.Infrastructure.Persistence.DatabaseConfiguration;
+
+internal interface IDatabaseAttributeConfig
+{
+    public bool IsSingleProperty { get;}
+    public string? HasColumnType { get; }
+    public string? HasConversionTypeFullName { get; }
+    public uint? HasMaxLength { get; }
+    public bool IsUnicode { get; }
+}

--- a/src/Nox.Generator/Infrastructure/Persistence/DatabaseConfiguration/IDatabaseAttributeConfiguration.cs
+++ b/src/Nox.Generator/Infrastructure/Persistence/DatabaseConfiguration/IDatabaseAttributeConfiguration.cs
@@ -1,0 +1,9 @@
+﻿using Nox.Solution;
+
+namespace Nox.Generator.Infrastructure.Persistence.DatabaseConfiguration
+{
+    internal interface IDatabaseAttributeConfiguration
+    {
+        IDatabaseAttributeConfig GetConfig(NoxSimpleTypeDefinition tyeDefinition);
+    }
+}

--- a/src/Nox.Generator/Infrastructure/Persistence/DatabaseConfiguration/MySqlDatabaseAttributeConfiguration.cs
+++ b/src/Nox.Generator/Infrastructure/Persistence/DatabaseConfiguration/MySqlDatabaseAttributeConfiguration.cs
@@ -1,0 +1,25 @@
+﻿using Nox.Solution;
+using Nox.Types;
+
+namespace Nox.Generator.Infrastructure.Persistence.DatabaseConfiguration;
+
+internal class MySqlDatabaseAttributeConfiguration : IDatabaseAttributeConfiguration
+{
+    public IDatabaseAttributeConfig GetConfig(NoxSimpleTypeDefinition tyeDefinition)
+    {
+        if (tyeDefinition.Type == NoxType.Text)
+        {
+            var options = tyeDefinition.TextTypeOptions ?? new TextTypeOptions();
+
+            var config = ConfigurationDefaults.GetDefaultOptions(options);
+            config.HasColumnType = $"VARCHAR({options.MaxLength})";
+        }
+        if (tyeDefinition.Type == NoxType.Number)
+        {
+            var options = tyeDefinition.NumberTypeOptions ?? new NumberTypeOptions();
+            return ConfigurationDefaults.GetDefaultOptions(options);
+        }
+        //For now return default => When Completed return Exception
+        return new DatabaseAttributeConfig() { };
+    }
+}

--- a/src/Nox.Generator/Infrastructure/Persistence/DatabaseConfiguration/SqliteDatabaseProvider.cs
+++ b/src/Nox.Generator/Infrastructure/Persistence/DatabaseConfiguration/SqliteDatabaseProvider.cs
@@ -1,0 +1,25 @@
+﻿using Nox.Solution;
+using Nox.Types;
+
+namespace Nox.Generator.Infrastructure.Persistence.DatabaseConfiguration
+{
+    internal class SqLiteDatabaseAttributeConfiguration : IDatabaseAttributeConfiguration
+    {
+        public IDatabaseAttributeConfig GetConfig(NoxSimpleTypeDefinition tyeDefinition)
+        {
+            if (tyeDefinition.Type == NoxType.Text)
+            {
+                var options = tyeDefinition.TextTypeOptions ?? new TextTypeOptions();
+                return ConfigurationDefaults.GetDefaultOptions(options);
+            }
+            if (tyeDefinition.Type == NoxType.Number)
+            {
+                var options = tyeDefinition.NumberTypeOptions ?? new NumberTypeOptions();
+                return ConfigurationDefaults.GetDefaultOptions(options);
+            }
+
+            //For now return default => When Completed return Exception
+            return new DatabaseAttributeConfig() { };
+        }
+    }
+}

--- a/src/Nox.Generator/Nox.Generator.cs
+++ b/src/Nox.Generator/Nox.Generator.cs
@@ -5,7 +5,6 @@ using Nox.Generator.Application.DtoGenerator;
 using Nox.Generator.Application.EventGenerator;
 using Nox.Generator.Domain.CqrsGenerators;
 using Nox.Generator.Domain.DomainEventGenerator;
-using Nox.Generator.Infrastructure.Persistence.ModelConfigGenerator;
 using Nox.Solution;
 using System;
 using System.Collections.Generic;
@@ -14,6 +13,7 @@ using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using Nox.Generator.Common;
+using Nox.Generator.Infrastructure.Persistence.EntityTypeDefinitionsGenerator;
 using YamlDotNet.Core;
 using YamlDotNet.Serialization;
 using YamlDotNet.Serialization.NamingConventions;
@@ -30,7 +30,7 @@ public class NoxCodeGenerator : IIncrementalGenerator
 #if DEBUG
         if (!Debugger.IsAttached)
         {
-            // Debugger.Launch(); 
+             Debugger.Launch(); 
         }
 #endif
         // var compilation = context.CompilationProvider.Select((ctx,token) => ctx.GlobalNamespace);

--- a/src/Nox.Generator/Nox.Generator.csproj
+++ b/src/Nox.Generator/Nox.Generator.csproj
@@ -27,7 +27,7 @@
     <PackageReference Include="YamlDotNet" Version="13.1.0" PrivateAssets="all" GeneratePathProperty="true" />
     <PackageReference Include="Humanizer.Core" Version="2.14.1" PrivateAssets="all" GeneratePathProperty="true" />
     <PackageReference Include="FluentValidation" Version="11.5.2" PrivateAssets="all" GeneratePathProperty="true" />
-    <PackageReference Include="Nox.Types" Version="1.0.8" PrivateAssets="all" GeneratePathProperty="true" />
+    <PackageReference Include="Nox.Types" Version="1.0.10" PrivateAssets="all" GeneratePathProperty="true" />
     <PackageReference Include="Nox.Solution" Version="1.0.13" PrivateAssets="all" GeneratePathProperty="true" />
   </ItemGroup>
   

--- a/src/Nox.Lib/Nox.Lib.csproj
+++ b/src/Nox.Lib/Nox.Lib.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
         <TargetFramework>net7.0</TargetFramework>
@@ -74,7 +74,7 @@
     <ItemGroup>
       <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="7.0.0" />
       <PackageReference Include="Nox.Solution" Version="1.0.13" />
-      <PackageReference Include="Nox.Types" Version="1.0.8" />
+      <PackageReference Include="Nox.Types" Version="1.0.10" />
       <PackageReference Include="Swashbuckle.AspNetCore.Annotations" Version="6.5.0" />
     </ItemGroup>
 </Project>

--- a/src/SampleWebApp/SampleWebApp.csproj
+++ b/src/SampleWebApp/SampleWebApp.csproj
@@ -45,6 +45,7 @@
     <PackageReference Include="Microsoft.EntityFrameworkCore" Version="7.0.7" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="7.0.7" />
     <PackageReference Include="Microsoft.OData.Core" Version="7.16.0" />
+    <PackageReference Include="Nox.Types.EntityFramework" Version="1.0.10" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.4.0" />
   </ItemGroup>
 

--- a/tests/NoxSourceGeneratorTests/NoxSourceGeneratorTests.csproj
+++ b/tests/NoxSourceGeneratorTests/NoxSourceGeneratorTests.csproj
@@ -19,7 +19,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.1.0" />
     <PackageReference Include="Nox.Solution" Version="1.0.13" />
-    <PackageReference Include="Nox.Types" Version="1.0.8" />
+    <PackageReference Include="Nox.Types" Version="1.0.10" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>


### PR DESCRIPTION
implement Nox.Type Text
Add this code to Nox.Generators is ok since we do not have any third party dependency, we are only generating strings, this accelerates development and we can move this to its on component if necessary

we may implement a DefaultConfig, would work generic in each db

we need to implement explicitly for each Nox.Type, bust this is centralized and encapsulated