### PR TITLE
Remove the early exitter

### DIFF
--- a/src/Nox.Secrets/UserSecretsResolver.cs
+++ b/src/Nox.Secrets/UserSecretsResolver.cs
@@ -24,7 +24,6 @@ public class UserSecretsResolver: ISecretsResolver
         {
             var secretValue = configuration[key.ToFlattenedKey("user").Replace('.', ':')]; 
             if (!string.IsNullOrWhiteSpace(secretValue)) result.Add(key, secretValue);
-            if (result.Any()) return result;
         }
 
         return result;


### PR DESCRIPTION
I believe this is a bug. When there is multiple user secret values, it was grabbing only the first one. Is it okay if we remove this line @jan-schutte ?