### PR TITLE
MP-8192 - Enable Dependabot to automate updates on stable dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,15 @@
+version: 2
+updates:
+  - package-ecosystem: "nuget"
+    directory: "/src" # Nox.Generator.sln
+    # Check for updates at 7 AM UTC
+    schedule:
+      interval: "daily"
+      time: "07:00"
+    groups:
+      dependencies:
+        patterns:
+          - "*"
+    ignore:
+      - dependency-name: "*"
+        update-types: ["version-update:semver-major"]


### PR DESCRIPTION
- Added dependabot
- Scheduled to check for minor and patch nuget package updates daily at 07:00 AM UTC
- Updates are checked for all projects inside Nox.Generator solution (Nox.Types.Benchmarks, CoreInterfaces.csproj and Nox.PackageManager.csproj are not part of the solution at this moment hence they are not being checked)