### PR TITLE
461 Password property types do not generate in dto

### DIFF
--- a/.nox/design/allnoxtypes.entity.nox.yaml
+++ b/.nox/design/allnoxtypes.entity.nox.yaml
@@ -154,4 +154,7 @@ attributes:
   - name: LatLongField
     description: LatLongField Nox Type
     type: latLong
+  - name: EncryptedTextField
+    description: EncryptedText Nox Type
+    type: encryptedText
     

--- a/src/Nox.Generator/Application/Dto/EntityDto.template.cs
+++ b/src/Nox.Generator/Application/Dto/EntityDto.template.cs
@@ -34,6 +34,9 @@ public partial class {{className}}
     {{- end}}
 {{- end }}
 {{- for attribute in entity.Attributes }}
+    {{- if componentsInfo[attribute.Name].IsReadable == false -}}
+        {{ continue; }}
+    {{- end}}
 
     /// <summary>
     /// {{attribute.Description}} ({{if attribute.IsRequired}}Required{{else}}Optional{{end}}).

--- a/src/Nox.Generator/Application/Dto/EntityDtoGenerator.cs
+++ b/src/Nox.Generator/Application/Dto/EntityDtoGenerator.cs
@@ -26,7 +26,11 @@ internal class EntityDtoGenerator : INoxCodeGenerator
         {
             var attributes = entity.Attributes ?? Enumerable.Empty<NoxSimpleTypeDefinition>();
             var componentsInfo = attributes
-               .ToDictionary(r => r.Name, key => new { IsSimpleType = key.Type.IsSimpleType(), ComponentType = GetSingleComponentSimpleType(key) });
+               .ToDictionary(r => r.Name, key => new { 
+                   IsSimpleType = key.Type.IsSimpleType(), 
+                   ComponentType = GetSingleComponentSimpleType(key),
+                   IsReadable = key.Type.IsReadableType()
+               });
 
             context.CancellationToken.ThrowIfCancellationRequested();
 

--- a/src/Nox.Generator/Application/Dto/EntityUpdateDto.template.cs
+++ b/src/Nox.Generator/Application/Dto/EntityUpdateDto.template.cs
@@ -15,6 +15,9 @@ public partial class {{className}}
 {
     //TODO Add owned Entities and update odata endpoints
 {{- for attribute in entity.Attributes }}
+    {{- if componentsInfo[attribute.Name].IsUpdatable == false -}}
+    {{ continue; }}
+    {{- end}}
     /// <summary>
     /// {{attribute.Description}} ({{if attribute.IsRequired}}Required{{else}}Optional{{end}}).
     /// </summary>

--- a/src/Nox.Generator/Application/Dto/EntityUpdateDtoGenerator.cs
+++ b/src/Nox.Generator/Application/Dto/EntityUpdateDtoGenerator.cs
@@ -26,7 +26,11 @@ internal class EntityUpdateDtoGenerator : INoxCodeGenerator
         {
             var attributes = entity.Attributes ?? Enumerable.Empty<NoxSimpleTypeDefinition>();
             var componentsInfo = attributes
-               .ToDictionary(r => r.Name, key => new { IsSimpleType = key.Type.IsSimpleType(), ComponentType = GetSingleComponentSimpleType(key) });
+               .ToDictionary(r => r.Name, key => new { 
+                   IsSimpleType = key.Type.IsSimpleType(), 
+                   ComponentType = GetSingleComponentSimpleType(key),
+                   IsUpdatable = key.Type.IsUpdatableType()
+               });
 
             context.CancellationToken.ThrowIfCancellationRequested();
 

--- a/src/Nox.Types.Abstractions/Attributes/Types/CompoundTypeAttribute.cs
+++ b/src/Nox.Types.Abstractions/Attributes/Types/CompoundTypeAttribute.cs
@@ -6,9 +6,14 @@ namespace Nox.Types;
 /// 
 /// </summary>
 [AttributeUsage(AttributeTargets.Field, AllowMultiple = false)]
-public class CompoundTypeAttribute : Attribute
+public class CompoundTypeAttribute : Attribute, IDtoGenerateControl
 {
-    public CompoundTypeAttribute() 
-    { 
+    public virtual bool Read { get; set; }
+    public virtual bool Update { get; set; }
+
+    public CompoundTypeAttribute(bool read = true, bool update = true) 
+    {
+        Read = read;
+        Update = update;
     }
 }

--- a/src/Nox.Types.Abstractions/Attributes/Types/IDtoGenerateControl.cs
+++ b/src/Nox.Types.Abstractions/Attributes/Types/IDtoGenerateControl.cs
@@ -1,0 +1,7 @@
+﻿namespace Nox.Types;
+
+internal interface IDtoGenerateControl
+{
+    public bool Read { get; set; }
+    public bool Update { get; set; }
+}

--- a/src/Nox.Types.Abstractions/Attributes/Types/SimpleTypeAttribute.cs
+++ b/src/Nox.Types.Abstractions/Attributes/Types/SimpleTypeAttribute.cs
@@ -6,11 +6,14 @@ namespace Nox.Types;
 /// 
 /// </summary>
 [AttributeUsage(AttributeTargets.Field, AllowMultiple = false)]
-public class SimpleTypeAttribute : Attribute
+public class SimpleTypeAttribute : Attribute, IDtoGenerateControl
 {
     public INoxTypeComponentsDiscover ComponentDiscover { get; }
 
-    public SimpleTypeAttribute(Type underlyingType)
+    public virtual bool Read { get; set; }
+    public virtual bool Update { get; set; }
+
+    public SimpleTypeAttribute(Type underlyingType, bool read = true, bool update = true)
     {
         if (typeof(INoxTypeComponentsDiscover).IsAssignableFrom(underlyingType))
         {
@@ -20,5 +23,8 @@ public class SimpleTypeAttribute : Attribute
         {
             ComponentDiscover = new NoxTypeComponentsDiscover(underlyingType);
         }
+
+        Read = read;
+        Update = update;
     }
 }

--- a/src/Nox.Types.Abstractions/Enums/NoxType.cs
+++ b/src/Nox.Types.Abstractions/Enums/NoxType.cs
@@ -123,7 +123,7 @@ public enum NoxType : uint
     [SimpleType(typeof(string))]
     Email = 3393987164,
     
-    [SimpleType(typeof(string))]
+    [SimpleType(typeof(string), Read = false, Update = false)]
     EncryptedText = 1841598137,
     
     [SimpleType(typeof(string))]
@@ -132,7 +132,7 @@ public enum NoxType : uint
     [SimpleType(typeof(Guid))]
     Guid = 1043908053,
 
-    [CompoundType]
+    [CompoundType(Read = false, Update = false)]
     [CompoundComponent("HashText", typeof(string))]
     [CompoundComponent("Salt", typeof(string))]
     HashedText = 3656553818,
@@ -176,7 +176,7 @@ public enum NoxType : uint
     [SimpleType(typeof(NumberTypeComponentsDiscover))]
     Number = 4223714796,
 
-    [CompoundType]
+    [CompoundType(Read = false, Update = false)]
     [CompoundComponent("HashedPassword", typeof(string))]
     [CompoundComponent("Salt", typeof(string))]
     Password = 1755902638,

--- a/src/Nox.Types.Abstractions/Extensions/NoxTypeExtensions.cs
+++ b/src/Nox.Types.Abstractions/Extensions/NoxTypeExtensions.cs
@@ -50,5 +50,25 @@ public static class NoxTypeExtensions
         }
         return EmptyComponents;
     }
-  
+
+    public static bool IsReadableType(this NoxType noxType)
+    {
+        return (noxType.DtoGenerateControl()?.Read) ?? true;
+    }
+
+    public static bool IsUpdatableType(this NoxType noxType)
+    {
+        return (noxType.DtoGenerateControl()?.Update) ?? true;
+    }
+
+    private static IDtoGenerateControl? DtoGenerateControl(this NoxType noxType)
+    {
+        if (noxType.IsSimpleType())
+            return noxType.ToMemberInfo().GetCustomAttribute<SimpleTypeAttribute>();
+        else if (noxType.IsCompoundType())
+            return noxType.ToMemberInfo().GetCustomAttribute<CompoundTypeAttribute>();
+
+        return null;
+    }
+
 }

--- a/src/SampleWebApp/Generated/Nox.Generator/Nox.Generator.NoxCodeGenerator/Dto.AllNoxTypeDto.g.cs
+++ b/src/SampleWebApp/Generated/Nox.Generator/Nox.Generator.NoxCodeGenerator/Dto.AllNoxTypeDto.g.cs
@@ -139,19 +139,9 @@ public partial class AllNoxTypeDto
     public VatNumberDto? VatNumberField { get; set; } 
 
     /// <summary>
-    /// Password Nox Type (Optional).
-    /// </summary>
-    public PasswordDto? PasswordField { get; set; } 
-
-    /// <summary>
     /// Money Nox Type (Optional).
     /// </summary>
     public MoneyDto? MoneyField { get; set; } 
-
-    /// <summary>
-    /// HashedTex Nox Type (Optional).
-    /// </summary>
-    public HashedTextDto? HashedTexField { get; set; } 
 
     /// <summary>
     /// LatLongField Nox Type (Optional).

--- a/src/SampleWebApp/Generated/Nox.Generator/Nox.Generator.NoxCodeGenerator/Dto.AllNoxTypeUpdateDto.g.cs
+++ b/src/SampleWebApp/Generated/Nox.Generator/Nox.Generator.NoxCodeGenerator/Dto.AllNoxTypeUpdateDto.g.cs
@@ -99,17 +99,9 @@ public partial class AllNoxTypeUpdateDto
     /// </summary>
     public VatNumberDto? VatNumberField { get; set; } 
     /// <summary>
-    /// Password Nox Type (Optional).
-    /// </summary>
-    public PasswordDto? PasswordField { get; set; } 
-    /// <summary>
     /// Money Nox Type (Optional).
     /// </summary>
     public MoneyDto? MoneyField { get; set; } 
-    /// <summary>
-    /// HashedTex Nox Type (Optional).
-    /// </summary>
-    public HashedTextDto? HashedTexField { get; set; } 
     /// <summary>
     /// LatLongField Nox Type (Optional).
     /// </summary>

--- a/src/SampleWebApp/Generated/Nox.Generator/Nox.Generator.NoxCodeGenerator/Entities.AllNoxType.g.cs
+++ b/src/SampleWebApp/Generated/Nox.Generator/Nox.Generator.NoxCodeGenerator/Entities.AllNoxType.g.cs
@@ -147,4 +147,9 @@ public partial class AllNoxType : AuditableEntityBase
     /// LatLongField Nox Type (Optional).
     /// </summary>
     public Nox.Types.LatLong? LatLongField { get; set; } = null!;
+
+    /// <summary>
+    /// EncryptedText Nox Type (Optional).
+    /// </summary>
+    public Nox.Types.EncryptedText? EncryptedTextField { get; set; } = null!;
 }

--- a/src/SampleWebApp/Generated/Nox.Generator/Nox.Generator.NoxCodeGenerator/Factories.AllNoxTypeMapper.g.cs
+++ b/src/SampleWebApp/Generated/Nox.Generator/Nox.Generator.NoxCodeGenerator/Factories.AllNoxTypeMapper.g.cs
@@ -132,5 +132,7 @@ public class AllNoxTypeMapper: EntityMapperBase<AllNoxType>
         {        
             entity.LatLongField = noxTypeValue;
         }
+
+        // TODO map EncryptedTextField EncryptedText remaining types and remove if else
     }
 }

--- a/src/SampleWebApp/Migrations/20230814123137_InitialCreate.Designer.cs
+++ b/src/SampleWebApp/Migrations/20230814123137_InitialCreate.Designer.cs
@@ -12,7 +12,7 @@ using SampleWebApp.Infrastructure.Persistence;
 namespace SampleWebApp.Migrations
 {
     [DbContext(typeof(SampleWebAppDbContext))]
-    [Migration("20230811165917_InitialCreate")]
+    [Migration("20230814123137_InitialCreate")]
     partial class InitialCreate
     {
         /// <inheritdoc />
@@ -87,6 +87,10 @@ namespace SampleWebApp.Migrations
 
                     b.Property<string>("DeletedBy")
                         .HasColumnType("nvarchar(max)");
+
+                    b.Property<byte[]>("EncryptedTextField")
+                        .IsUnicode(false)
+                        .HasColumnType("varbinary(max)");
 
                     b.Property<uint?>("NuidField")
                         .HasColumnType("bigint");

--- a/src/SampleWebApp/Migrations/20230814123137_InitialCreate.cs
+++ b/src/SampleWebApp/Migrations/20230814123137_InitialCreate.cs
@@ -59,6 +59,7 @@ namespace SampleWebApp.Migrations
                     HashedTexField_Salt = table.Column<string>(type: "nvarchar(max)", nullable: true),
                     LatLongField_Latitude = table.Column<decimal>(type: "decimal(8,6)", precision: 8, scale: 6, nullable: true),
                     LatLongField_Longitude = table.Column<decimal>(type: "decimal(9,6)", precision: 9, scale: 6, nullable: true),
+                    EncryptedTextField = table.Column<byte[]>(type: "varbinary(max)", unicode: false, nullable: true),
                     CreatedAtUtc = table.Column<DateTime>(type: "datetime2", nullable: false),
                     CreatedBy = table.Column<string>(type: "nvarchar(max)", nullable: true),
                     UpdatedAtUtc = table.Column<DateTime>(type: "datetime2", nullable: true),

--- a/src/SampleWebApp/Migrations/SampleWebAppDbContextModelSnapshot.cs
+++ b/src/SampleWebApp/Migrations/SampleWebAppDbContextModelSnapshot.cs
@@ -85,6 +85,10 @@ namespace SampleWebApp.Migrations
                     b.Property<string>("DeletedBy")
                         .HasColumnType("nvarchar(max)");
 
+                    b.Property<byte[]>("EncryptedTextField")
+                        .IsUnicode(false)
+                        .HasColumnType("varbinary(max)");
+
                     b.Property<uint?>("NuidField")
                         .HasColumnType("bigint");
 

--- a/tests/Nox.Generator.Tests/files/yaml/domain/query.solution.nox.yaml
+++ b/tests/Nox.Generator.Tests/files/yaml/domain/query.solution.nox.yaml
@@ -178,3 +178,15 @@ domain:
           type: text
           textTypeOptions:
             maxLength: 31
+
+        - name: EncryptedTextField
+          description: EncryptedText Nox Type
+          type: encryptedText
+
+        - name: HashedTextField
+          description: HashedText Nox Type
+          type: hashedText
+
+        - name: PasswordField
+          description: Password Nox Type
+          type: password


### PR DESCRIPTION
At the moment I've added options for Read and Update only, as Create Dto is generated from Update Dto, and Delete option cannot be implemented as we delete the whole entity not its single property. So Delete option can be added later.  